### PR TITLE
Fix autoconnect on IOS

### DIFF
--- a/lib/src/exception_serializer.dart
+++ b/lib/src/exception_serializer.dart
@@ -14,6 +14,9 @@ void rethrowException(e) {
   final details = e.details;
 
   if (Platform.isIOS) {
+    if(message.toString().contains("RxBluetoothKit.BluetoothError error 4")){
+      throw BleDisconnectedException(message, details);
+    }
     throw BleException(message, details);
   }
 


### PR DESCRIPTION
This fixes autoconnect function on IOS.

To Test : 
Set autoconnect parameter true in main.dart of example app.