### PR TITLE
Fix: rssi value does not refresh in IOS

### DIFF
--- a/ios/Classes/ScanMethods.swift
+++ b/ios/Classes/ScanMethods.swift
@@ -32,7 +32,7 @@ class ScanMethods: NSObject {
 
         _stopScan()
 
-        disposable = manager.scanForPeripherals(withServices: services).subscribe(
+        disposable = manager.scanForPeripherals(withServices: services,options: [CBCentralManagerScanOptionAllowDuplicatesKey : true]).subscribe(
             onNext: {
                 let peripheral = $0.peripheral
                 let deviceName = peripheral.name


### PR DESCRIPTION
This fixes issue : rssi value does not refresh in IOS

To Test :
In example/main.dart change Line 309 to - 
`"connect(${scanResult.rssi.toString()} ${scanResult.deviceId})",`